### PR TITLE
Allow outputting the reference number in groups of five digits

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ The above example prints out “11112”.
     
 The above example prints out zero padded reference number "00000000000000011112".
 
+    ReferenceNumber.new("111122223333", :grouping => true).to_s
+
+The above example prints out a reference number in groups of five digits for better legibility "111 12222 33336".
+
 This example shows how to generate a series of reference number:
 
     (1000..1023).to_a.each do |number|

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ReferenceNumber
 
-Ruby library for calculating reference number (viitenumere, referensnummer).
+Ruby library for calculating reference number (viitenumero, referensnummer).
 
 Original idea and code was gotten from Christian:
 http://snippets.aktagon.com/snippets/51-How-to-Calculate-a-reference-number-with-Ruby

--- a/lib/reference_number.rb
+++ b/lib/reference_number.rb
@@ -1,12 +1,13 @@
 class ReferenceNumber
   class InvalidReferenceNumber < ArgumentError
   end
-  
+
   attr_accessor :input
-  
-  def initialize(input, opts = { :zero_padding => false })
+
+  def initialize(input, opts = { :zero_padding => false, :grouping => false })
     @zero_padding = opts[:zero_padding]
-    
+    @grouping = opts[:grouping]
+
     @input = input
     if(@input.is_a? Fixnum)
       @input = @input.to_s
@@ -38,11 +39,9 @@ class ReferenceNumber
     difference = (10 - (sum % 10)) % 10
     difference_and_input = "#{difference}#{@input}".reverse
 
-    if @zero_padding
-      "%020d" % difference_and_input if @zero_padding
-    else
-      difference_and_input
-    end
+    difference_and_input = "%020d" % difference_and_input if @zero_padding
+    difference_and_input = difference_and_input.reverse.scan(/\d{1,5}/).join(" ").reverse if @grouping
+    difference_and_input
   end
 
 end

--- a/spec/reference_number_spec.rb
+++ b/spec/reference_number_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe ReferenceNumber do
-    
+
   it "gives the right reference number when input is right" do
     ReferenceNumber.new(100).to_s.should == "1009"
     ReferenceNumber.new("100").to_s.should == "1009"
@@ -13,11 +13,21 @@ describe ReferenceNumber do
     ReferenceNumber.new("123123123234234234").to_s.should == "1231231232342342349"
     ReferenceNumber.new("1000000000").to_s.should == "10000000003"
   end
-  
+
   it "pads the reference number when asked to" do
     ReferenceNumber.new("100", :zero_padding => true).to_s.should == "00000000000000001009"
   end
-  
+
+  it "groups the reference number when asked to" do
+    ReferenceNumber.new("100", :grouping => true).to_s.should == "1009"
+    ReferenceNumber.new("10000", :grouping => true).to_s.should == "1 00007"
+    ReferenceNumber.new("123123123234234234", :grouping => true).to_s.should == "1231 23123 23423 42349"
+  end
+
+  it "allows both padding and grouping at the same time" do
+    ReferenceNumber.new("100", :zero_padding => true, :grouping => true).to_s.should == "00000 00000 00000 01009"
+  end
+
   it "gives an error, if the input is incorrect" do
     lambda {ReferenceNumber.new("")}.should raise_error(ReferenceNumber::InvalidReferenceNumber)
     lambda {ReferenceNumber.new("     ")}.should raise_error(ReferenceNumber::InvalidReferenceNumber)
@@ -25,5 +35,5 @@ describe ReferenceNumber do
     lambda {ReferenceNumber.new(1)}.should raise_error(ReferenceNumber::InvalidReferenceNumber)
     lambda {ReferenceNumber.new("0000")}.should raise_error(ReferenceNumber::InvalidReferenceNumber)
   end
-  
+
 end


### PR DESCRIPTION
This patch adds an option to group the reference number like so: 111 12222 33336. It's easier to read this way. And it's totally legal too: [pdf](http://www.fkl.fi/teemasivut/sepa/tekninen_dokumentaatio/Dokumentit/kotimaisen_viitteen_rakenneohje.pdf)

Also, fixes a typo in README so google can find this library.
